### PR TITLE
Add ability to specify channel when scanning to check power output for a single channel.

### DIFF
--- a/src/c0_detect.cc
+++ b/src/c0_detect.cc
@@ -58,7 +58,7 @@ vectornorm2 (const complex * v, const unsigned int len)
 
 
 int
-c0_detect (usrp_source * u, int bi)
+c0_detect (usrp_source * u, int bi, int chan)
 {
 
 #define GSM_RATE (1625000.0 / 6.0)
@@ -91,6 +91,11 @@ c0_detect (usrp_source * u, int bi)
   u->flush ();
   for (i = first_chan (bi); i >= 0; i = next_chan (i, bi))
     {
+      if (chan > -1 && chan != i)
+        {
+          power[i] = 0;
+          continue;
+        }
       freq = arfcn_to_freq (i, &bi);
       if (!u->tune (freq))
 	{
@@ -149,7 +154,7 @@ c0_detect (usrp_source * u, int bi)
   i = first_chan (bi);
   do
     {
-      if (power[i] <= a)
+      if ((chan > -1 && i != chan) || (chan == -1 && power[i] <= a))
 	{
 	  i = next_chan (i, bi);
 	  continue;

--- a/src/c0_detect.h
+++ b/src/c0_detect.h
@@ -25,4 +25,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int c0_detect (usrp_source * u, int bi);
+int c0_detect (usrp_source * u, int bi, int channel);

--- a/src/kal.cc
+++ b/src/kal.cc
@@ -310,5 +310,5 @@ main (int argc, char **argv)
   fprintf (stderr, "%s: Scanning for %s base stations.\n",
 	   basename (argv[0]), bi_to_str (bi));
 
-  return c0_detect (u, bi);
+  return c0_detect (u, bi, chan);
 }


### PR DESCRIPTION
These changes allow you to use the -s (scan) parameter with the -c (channel) parameter to check the power of a single channel. I have used this when I want to test/aim different GSM antennas. I do a normal -s scan (which for example takes 3 minutes for GSM850) and determine which channels are active, then I do individual channel scans on a single channel (which takes a few seconds) while I'm aiming or testing different antennas.