### PR TITLE
Fix library not found for -lrt on OS X. Closes GH-7

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,8 @@ PKG_CHECK_MODULES(LIBHACKRF, libhackrf)
 AC_SUBST(LIBHACKRF_LIBS)
 AC_SUBST(LIBHACKRF_CFLAGS)
 
+AM_CONDITIONAL([DARWIN], false)
+
 # OSX doesn't support System V shared memory
 AC_CANONICAL_HOST
 case "$host_os" in
@@ -45,8 +47,6 @@ case "$host_cpu" in
 		AC_DEFINE([D_HOST_OSX], [], [building without shared memory])
 		;;
 esac
-
-AM_CONDITIONAL([DARWIN], false)
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile])


### PR DESCRIPTION
Closes https://github.com/scateu/kalibrate-hackrf/issues/7, by moving the conditional default above where it is set for Darwin, so Darwin can take precedence (fixes https://github.com/scateu/kalibrate-hackrf/commit/b8b82f9cf590e6251645bb0ecdfe9922f8b884fe)